### PR TITLE
Support newer "AWS Control Tower Account Factory" versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
+## 0.4.3 (2024-10-04)
+
+- Support newer "AWS Control Tower Account Factory" versions
+
 ## 0.4.2 (2022-11-02)
 
-- Fix AWS account provisioning.
-- Fix moving AWS account to new OU.
-- Require at least Go 1.18 to build plugin.
-- Update `mcaf_aws_account` docs.
-- Update Go module versions to latest versions.
+- Add `mcaf_aws_all_organizational_units` data resource
+- Fix `mcaf_aws_account` so it can move accounts to new organizational units
+- Update `mcaf_aws_account` docs
+- Update `mcaf_aws_account` to provision accounts using updated Service Catalog fields
+- Update module versions and require minimum Go 1.18 to build plugin
 
 ## 0.4.1 (2022-03-08)
 

--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -3,12 +3,12 @@ layout: "mcaf"
 page_title: "Provider: MCAF"
 sidebar_current: "docs-mcaf-index"
 description: |-
-  The MCAF provider is used to interact certain AWS and O365 APIs.
+  The MCAF provider is used to provide additional functionality not available in official or community providers.
 ---
 
 # MCAF Provider
 
-The MCAF provider is used to interact with AWS and Office 365 via the ExoAPI.
+The MCAF provider is used to provide additional functionality not available in official or community providers.
 
 Use the navigation to the left to read about the available resources.
 

--- a/website/docs/r/aws_account.html.markdown
+++ b/website/docs/r/aws_account.html.markdown
@@ -14,9 +14,9 @@ Creates an AWS account using Control Tower's Account Factory.
 
 ```hcl
 resource "mcaf_aws_account" "example" {
-  name                = "foo"
-  email               = "foo@example"
-  organizational_unit = "My-OU"
+  name                     = "foo"
+  email                    = "foo@example"
+  organizational_unit_path = "My-OU"
 
   sso {
     firstname = "Control Tower"
@@ -32,9 +32,9 @@ It is also possible to create an AWS account in a nested organizational unit by 
 
 ```hcl
 resource "mcaf_aws_account" "example" {
-  name                = "foo"
-  email               = "foo@example"
-  organizational_unit = "My-Team/My-Project/My-Env"
+  name                     = "foo"
+  email                    = "foo@example"
+  organizational_unit_path = "My-Team/My-Project/My-Env"
 
   sso {
     firstname = "Control Tower"
@@ -48,26 +48,28 @@ resource "mcaf_aws_account" "example" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the account.
+- `name` - (Required) The name of the account.
 
-* `email` - (Required) The email address of the account.
+- `email` - (Required) The email address of the account.
 
-* `organizational_unit` - (Optional) The Organizational Unit to place the account in. **Deprecated** This argument has been replaced by `organizational_unit_path` and will be removed in a future version.
+- `organizational_unit` - (Optional) The Organizational Unit to place the account in. **Deprecated** This argument has been replaced by `organizational_unit_path` and will be removed in a future version.
 
-* `organizational_unit_path` - (Optional) The Organizational Unit path to place the account in.
+- `organizational_unit_path` - (Optional) The Organizational Unit path to place the account in.
 
-* `provisioned_product_name` - (Optional) A custom name for the provisioned product.
+- `provisioned_product_path_id` - (Optional) The launch path ID of the `AWS Control Tower Account Factory` product. If not provided, the provider will attempt to look it up itself.
+
+- `provisioned_product_name` - (Optional) A custom name for the provisioned product.
 
 The `sso` object supports the following:
 
-* `firstname` - (Required) The first name of the Control Tower SSO account.
+- `firstname` - (Required) The first name of the Control Tower SSO account.
 
-* `lastname` - (Required) The lastname of the Control Tower SSO account.
+- `lastname` - (Required) The lastname of the Control Tower SSO account.
 
-* `email` - (Required) The email address of the Control Tower SSO account.
+- `email` - (Required) The email address of the Control Tower SSO account.
 
 ## Attributes Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `account_id` - The ID of the AWS account.
+- `account_id` - The ID of the AWS account.


### PR DESCRIPTION
Since the last Control Tower update, the Service Catalog product contains a path ID that needs to be provided when provisioning an account using the Account Factory.

We attempt to look it up, and if we find it use it, or skip it if not found to support older versions. If we find more than one path ID then error out and ask the user to supply the path ID by hand using the `provisioned_product_path_id` field.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
