### PR TITLE
chore: Switch to `pull_request_target`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   fmt:


### PR DESCRIPTION
We need the action to access secrets, which `pull_request_target` lets us do.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
